### PR TITLE
Add constructor for `FactorGraph` from `IndexedGraph`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,4 +15,5 @@ makedocs(sitename="IndexedGraphs Documentation",
 
 deploydocs(
     repo = "github.com/stecrotti/IndexedGraphs.jl.git",
+    push_preview = true,
 )

--- a/docs/src/factor.md
+++ b/docs/src/factor.md
@@ -8,6 +8,7 @@ FactorGraph
 
 ```@docs
 FactorGraph(A::AbstractMatrix)
+FactorGraph(g::IndexedGraph)
 ```
 
 ```@meta

--- a/src/IndexedGraphs.jl
+++ b/src/IndexedGraphs.jl
@@ -24,7 +24,7 @@ import TrackingHeaps:
 
 export
     idx, ==, iterate,
-    AbstractIndexedGraph, inedges, outedges,
+    AbstractIndexedGraph, inedges, outedges, adjacency_matrix,
     # undirected graphs
     IndexedGraph, get_edge,
     # directed graphs

--- a/src/factorgraph.jl
+++ b/src/factorgraph.jl
@@ -30,6 +30,19 @@ function FactorGraph(A::AbstractMatrix)
 	FactorGraph(SparseMatrixCSC(A.m, A.n, A.colptr, A.rowval, fill(NullNumber(), length(A.nzval))))
 end
 
+"""
+    FactorGraph(g::IndexedGraph)
+
+Construct a factor graph whose factors are the pair-wise interactions encoded in `g`.
+"""
+function FactorGraph(g::IndexedGraph)
+    I = reduce(vcat, [idx(e), idx(e)] for e in edges(g)) 
+    J = reduce(vcat, [src(e), dst(e)] for e in edges(g)) 
+    K = ones(Int, 2*ne(g))
+    A = sparse(I, J, K)
+    FactorGraph(A)
+end
+
 function Base.show(io::IO, g::FactorGraph{T}) where T
     nvar = nvariables(g)
     nfact = nfactors(g)
@@ -175,7 +188,7 @@ end
 has_vertex(g::FactorGraph, v::Variable) = v.i ≤ nvariables(g)
 has_vertex(g::FactorGraph, f::Factor) = f.a ≤ nfactors(g)
 has_vertex(g::FactorGraph, i::Int) = i ≤ nv(g)
-has_edge(g::FactorGraph, f::Factor, v::Variable) = g.A[f.a, v.i] != 0
+has_edge(g::FactorGraph, f::Factor, v::Variable) = !iszero(g.A[f.a, v.i])
 has_edge(g::FactorGraph, v::Variable, f::Factor) = has_edge(g, f, v)
 
 # return true if (src, dst) is an edge in the bipartite view of g

--- a/src/factorgraph.jl
+++ b/src/factorgraph.jl
@@ -134,7 +134,7 @@ function edges(g::FactorGraph, v::Variable)
 end
 
 """
-    neighbors(g::FactorGraph, f::Factor)
+    edges(g::FactorGraph, f::Factor)
 
 Return a lazy iterator to the edges incident to factor `f`
 """

--- a/test/factorgraph.jl
+++ b/test/factorgraph.jl
@@ -44,4 +44,20 @@ g = FactorGraph(A)
         gg = bipartite_view(g)
         @test is_bipartite(gg)
     end
+
+    @testset "from pairwise graph" begin
+        B = sprand(Bool, 20, 20, 0.5)
+        for i in 1:20; B[i,i] = 0; end
+        B = B + B'
+        dropzeros!(B)
+        gpair = IndexedGraph(B)
+        gfact = FactorGraph(gpair)
+        @test nfactors(gfact) == ne(gpair)
+        @test nvariables(gfact) == nv(gpair)
+        @test all(
+            has_edge(gfact, Variable(i), Factor(id)) &&
+            has_edge(gfact, Variable(j), Factor(id))
+            for (i, j, id) in edges(gpair)
+            )
+    end
 end


### PR DESCRIPTION
Use case: you have pairwise interactions encoded in a `IndexedGraph` and you want to build the corresponding factor graph with one factor for each edge in the original graph