### PR TITLE
Complete bidigraph

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,12 @@ version = "0.4.2"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
-Lazy = "50d2b5c4-7a5e-59d5-8109-a42b560f39c0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TrackingHeaps = "d94bfb22-46ad-56c3-87d0-f6c298cb800e"
 
 [compat]
-Lazy = "0.15"
 Graphs = "1.4 - 1.9"
 Reexport = "1"
 TrackingHeaps = "0.1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.4.2"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+Lazy = "50d2b5c4-7a5e-59d5-8109-a42b560f39c0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TrackingHeaps = "d94bfb22-46ad-56c3-87d0-f6c298cb800e"
 
 [compat]
+Lazy = "0.15"
 Graphs = "1.4 - 1.9"
 Reexport = "1"
 TrackingHeaps = "0.1"

--- a/docs/src/bidigraph.md
+++ b/docs/src/bidigraph.md
@@ -7,10 +7,12 @@ For a lighter data structure check out [IndexedDiGraph](@ref).
 
 ```@docs
 IndexedBiDiGraph
+CompleteIndexedBiDiGraph
 ```
 
 ```@docs
 IndexedBiDiGraph(A::AbstractMatrix)
+CompleteIndexedBiDiGraph(g::IndexedGraph)
 ```
 Example:
 ```@example
@@ -21,5 +23,3 @@ dropzeros!(At)
 g = IndexedBiDiGraph(transpose(At))  
 g.A.rowval === At.rowval
 ```
-
-

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,6 +7,6 @@ This package defines three basic types of Graphs:
 - [IndexedDiGraph](@ref)
 - [IndexedBiDiGraph](@ref)
 
-In addition, it provides a [BipartiteIndexedGraph](@ref) type.
+In addition, it provides a [BipartiteIndexedGraph](@ref) and a [CompleteIndexedBiDiGraph](@ref) type.
 
 They all comply with the [Developing Alternate Graph Types](https://juliagraphs.org/Graphs.jl/dev/developing/) rules for subtyping from `Graphs.AbstractGraph`.

--- a/src/IndexedGraphs.jl
+++ b/src/IndexedGraphs.jl
@@ -15,7 +15,7 @@ using Reexport
     SimpleGraph, SimpleDiGraph, AbstractSimpleGraph
 using Graphs
 
-import Graphs.LinAlg:
+@reexport import Graphs.LinAlg:
     adjacency_matrix
 
 import LinearAlgebra:
@@ -26,11 +26,12 @@ import TrackingHeaps:
 
 export
     idx, ==, iterate,
-    AbstractIndexedGraph, inedges, outedges, adjacency_matrix,
+    AbstractIndexedGraph, inedges, outedges,
     # undirected graphs
     IndexedGraph, get_edge,
     # directed graphs
     AbstractIndexedDiGraph, IndexedDiGraph, IndexedBiDiGraph,
+    CompleteIndexedBiDiGraph,
     # bipartite graphs
     BipartiteIndexedGraph, Left, Right, LeftorRight, BipartiteGraphVertex,
     nv_left, nv_right, vertex, linearindex, vertices_left, vertices_right,

--- a/src/indexedbidigraph.jl
+++ b/src/indexedbidigraph.jl
@@ -71,7 +71,7 @@ A wrapper type over a `IndexedBiDiGraph` representing a sparse directed graph wh
 struct CompleteIndexedBiDiGraph{T<:Integer} <: AbstractIndexedDiGraph{T}
     g :: IndexedBiDiGraph{T}
 
-    """
+    @doc """
         CompleteIndexedBiDiGraph(g::IndexedGraph)
 
     Construct a `CompleteIndexedBiDiGraph` from an `IndexedGraph` `g` by building two directed edges per every undirected edge in `g`
@@ -91,12 +91,11 @@ Graphs.ne(g::CompleteIndexedBiDiGraph) = ne(g.g)
 Graphs.nv(g::CompleteIndexedBiDiGraph) = nv(g.g)
 Graphs.edges(g::CompleteIndexedBiDiGraph) = edges(g.g)
 Graphs.vertices(g::CompleteIndexedBiDiGraph) = vertices(g.g)
-Graphs.vertices(g::CompleteIndexedBiDiGraph) = vertices(g.g)
 Graphs.is_bipartite(g::CompleteIndexedBiDiGraph) = is_bipartite(g.g)
 Graphs.LinAlg.adjacency_matrix(g::CompleteIndexedBiDiGraph) = adjacency_matrix(g.g)
 
 Graphs.has_vertex(g::CompleteIndexedBiDiGraph, i::Integer) = has_vertex(g.g, i)
-Graphs.has_vertex(g::CompleteIndexedBiDiGraph, i::Integer) = has_vertex(g.g, i)
+Graphs.has_edge(g::CompleteIndexedBiDiGraph, i::Integer, j::Integer) = has_edge(g.g, i, j)
 Graphs.neighbors(g::CompleteIndexedBiDiGraph, i::Integer) = neighbors(g.g, i)
 Graphs.inneighbors(g::CompleteIndexedBiDiGraph, i::Integer) = inneighbors(g.g, i)
 Graphs.outneighbors(g::CompleteIndexedBiDiGraph, i::Integer) = outneighbors(g.g, i)

--- a/src/indexedbidigraph.jl
+++ b/src/indexedbidigraph.jl
@@ -59,11 +59,51 @@ function adjacency_matrix(g::IndexedBiDiGraph, T::DataType=Int)
     SparseMatrixCSC(g.X.m, g.X.n, g.X.colptr, g.X.rowval, ones(T, nnz(g.X)))
 end
 
+"""
+    CompleteIndexedBiDiGraph{T<:Integer} <: AbstractIndexedDiGraph{T}       
+
+A wrapper type over a `IndexedBiDiGraph` representing a sparse directed graph where between each pair of vertices `i,j` there exist either no edge or both directed edges `i=>j` and `j=>i`.
+
+### FIELDS
+
+- `g` -- the underlying digraph.
+"""
 struct CompleteIndexedBiDiGraph{T<:Integer} <: AbstractIndexedDiGraph{T}
     g :: IndexedBiDiGraph{T}
 
+    """
+        CompleteIndexedBiDiGraph(g::IndexedGraph)
+
+    Construct a `CompleteIndexedBiDiGraph` from an `IndexedGraph` `g` by building two directed edges per every undirected edge in `g`
+    """
     function CompleteIndexedBiDiGraph(g::IndexedGraph{T}) where {T<:Integer}
         gd = IndexedBiDiGraph(adjacency_matrix(g))
         new{T}(gd)
     end
 end
+
+function Base.show(io::IO, g::CompleteIndexedBiDiGraph{T}) where T
+    println(io, "{$(nv(g)), $(ne(g))} CompleteIndexedBiDiGraph{$T}")
+end
+
+Graphs.edgetype(g::CompleteIndexedBiDiGraph) = edgetype(g.g)
+Graphs.ne(g::CompleteIndexedBiDiGraph) = ne(g.g)
+Graphs.nv(g::CompleteIndexedBiDiGraph) = nv(g.g)
+Graphs.edges(g::CompleteIndexedBiDiGraph) = edges(g.g)
+Graphs.vertices(g::CompleteIndexedBiDiGraph) = vertices(g.g)
+Graphs.vertices(g::CompleteIndexedBiDiGraph) = vertices(g.g)
+Graphs.is_bipartite(g::CompleteIndexedBiDiGraph) = is_bipartite(g.g)
+Graphs.LinAlg.adjacency_matrix(g::CompleteIndexedBiDiGraph) = adjacency_matrix(g.g)
+
+Graphs.has_vertex(g::CompleteIndexedBiDiGraph, i::Integer) = has_vertex(g.g, i)
+Graphs.has_vertex(g::CompleteIndexedBiDiGraph, i::Integer) = has_vertex(g.g, i)
+Graphs.neighbors(g::CompleteIndexedBiDiGraph, i::Integer) = neighbors(g.g, i)
+Graphs.inneighbors(g::CompleteIndexedBiDiGraph, i::Integer) = inneighbors(g.g, i)
+Graphs.outneighbors(g::CompleteIndexedBiDiGraph, i::Integer) = outneighbors(g.g, i)
+Graphs.degree(g::CompleteIndexedBiDiGraph, i::Integer) = degree(g.g, i)
+
+inedges(g::CompleteIndexedBiDiGraph, i::Integer) = inedges(g.g, i)
+outedges(g::CompleteIndexedBiDiGraph, i::Integer) = outedges(g.g, i)
+
+get_edge(g::CompleteIndexedBiDiGraph, id::Integer) = get_edge(g.g, id)
+get_edge(g::CompleteIndexedBiDiGraph, src::Integer, dst::Integer) = get_edge(g.g, src, dst)

--- a/src/indexedbidigraph.jl
+++ b/src/indexedbidigraph.jl
@@ -58,3 +58,12 @@ inedges(g::IndexedBiDiGraph, i::Integer) = @inbounds (IndexedEdge{Int}(g.X.rowva
 function adjacency_matrix(g::IndexedBiDiGraph, T::DataType=Int)
     SparseMatrixCSC(g.X.m, g.X.n, g.X.colptr, g.X.rowval, ones(T, nnz(g.X)))
 end
+
+struct CompleteIndexedBiDiGraph{T<:Integer} <: AbstractIndexedDiGraph{T}
+    g :: IndexedBiDiGraph{T}
+
+    function CompleteIndexedBiDiGraph(g::IndexedGraph{T}) where {T<:Integer}
+        gd = IndexedBiDiGraph(adjacency_matrix(g))
+        new{T}(gd)
+    end
+end

--- a/test/indexedbidigraph.jl
+++ b/test/indexedbidigraph.jl
@@ -54,3 +54,43 @@ g = IndexedBiDiGraph(A)
         @test adjacency_matrix(sg) == adjacency_matrix(ig)
     end
 end
+
+@testset "complete BiDirected graph" begin
+
+    A = sprand(Bool, 20, 20, 0.5)
+    for i in 1:20; A[i,i] = 0; end
+    A = A + A'
+    dropzeros!(A)
+    g = CompleteIndexedBiDiGraph(IndexedGraph(A))
+    gd = IndexedBiDiGraph(A)
+
+    @testset "show" begin
+        buf = IOBuffer()
+        show(buf, g)
+        @test String(take!(buf)) == "{20, $(ne(g))} CompleteIndexedBiDiGraph{$(Int)}\n"
+    end
+
+    @testset "basics" begin
+        @test is_directed(typeof(g)) == is_directed(typeof(gd))
+        @test is_directed(g) == is_directed(gd)
+        @test length(collect(edges(g))) == ne(g) == length(collect(edges(gd))) == ne(gd)
+        i = 3
+        ine = inedges(g, i); ined = inedges(gd, i)
+        inn = inneighbors(g, i); innd = inneighbors(gd, i)
+        @test all(src(e) == j == src(ed) == jd for (e,j,ed,jd) in zip(ine, inn, ined, innd))
+        @test all(dst(e) == i == dst(ed) for (e, ed) in zip(ine, ined))
+    end
+
+    @testset "edge indexing" begin
+        @test all( e == get_edge(g, src(e), dst(e)) for e in edges(g) )
+        @test all( e == get_edge(g, idx(e)) for e in edges(g) )
+
+        passed = falses(ne(g))
+        for (i,e) in enumerate(edges(g))
+            id = idx(get_edge(g, src(e), dst(e)))
+            ee = get_edge(g, id)
+            passed[i] = ee == e
+        end
+        @test all(passed)
+    end
+end


### PR DESCRIPTION
Introduce a `CompleteIndexedBiDiGraph` which is a digraph with the additional property that for each edge `i=>j` there always exists the parallel edge `j=>i`. 

For instance, message-passing algorithms might tacitly assume this property to hold, so i though we should do a type that guarantees the property.