### PR TITLE
Add tools for symmetric bidigraphs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IndexedGraphs"
 uuid = "8a731c18-cfb7-4915-927e-cc26b56b67cd"
 authors = ["Stefano Crotti <stefano.crotti@polito.it>", "Alfredo Braunstein <alfredo.braunstein@polito.it>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IndexedGraphs"
 uuid = "8a731c18-cfb7-4915-927e-cc26b56b67cd"
 authors = ["Stefano Crotti <stefano.crotti@polito.it>", "Alfredo Braunstein <alfredo.braunstein@polito.it>"]
-version = "0.4.3"
+version = "0.5.0"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"

--- a/src/IndexedGraphs.jl
+++ b/src/IndexedGraphs.jl
@@ -34,8 +34,9 @@ export
     # bipartite graphs
     BipartiteIndexedGraph, Left, Right, LeftorRight, BipartiteGraphVertex,
     nv_left, nv_right, vertex, linearindex, vertices_left, vertices_right,
-    vertex_left, vertex_right,
-    is_directed
+    vertex_left, vertex_right, 
+    is_directed, issymmetric,
+    bidirected_with_mappings
 
 """
     AbstractIndexedEdge{T<:Integer} <: AbstractEdge{T}

--- a/test/indexedbidigraph.jl
+++ b/test/indexedbidigraph.jl
@@ -53,4 +53,25 @@ g = IndexedBiDiGraph(A)
         ig = IndexedBiDiGraph(sg)
         @test adjacency_matrix(sg) == adjacency_matrix(ig)
     end
+
+    @testset "construct from IndexedGraph" begin
+        B = A + A'
+        dropzeros!(B)
+        g = IndexedGraph(B)
+        gd, dir2undir, undir2dir = bidirected_with_mappings(g)
+        @test issymmetric(gd)
+    
+        eu = edges(g) |> collect    # undirected edges
+        ed = edges(gd) |> collect   # directed edges
+        @test all( let
+            e = eu[dir2undir[idd]]
+            src(e) == min(i,j) && dst(e) == max(i,j)
+        end for (i,j,idd) in ed
+        )
+        @test all( let
+            es = ed[undir2dir[idu]]
+            src(es[1]) == dst(es[2]) && src(es[2]) == dst(es[1])
+        end for (i,j,idu) in eu
+        )
+    end
 end

--- a/test/indexedbidigraph.jl
+++ b/test/indexedbidigraph.jl
@@ -7,6 +7,10 @@ g = IndexedBiDiGraph(A)
 
 @testset "BiDirected graph" begin
 
+    @testset "issymmetric" begin
+        @test issymmetric(g) == issymmetric(adjacency_matrix(g))
+    end
+
     @testset "show" begin
         buf = IOBuffer()
         show(buf, g)


### PR DESCRIPTION
After all i think all the new stuff in #28 is not really necessary. 

This PR is a thinner alternative. It implements:
- A function `bidirected_with_mappings` which takes an undirected graph and builds the corresponding bidirected graph. In addition it returns two mappings linking the indices of the edges of the two graphs. This turns out useful when you have some properties of the undirected edge `(i,j)` but you need it while looping on the directed edges.
- A method `issymmetric(g::IndexedBiDiGraph)` that checks whether the graph has the property that for each edge `i=>j` there always exists the parallel edge `j=>i`. There's no need for a new type.